### PR TITLE
 Fixing iptables issue when default policy is drop

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,7 @@ concourse_tsa_port: 2222
 #concourse_worker_tag:
 #concourse_worker_team:
 #concourse_worker_options:
+
+# Make sure garden linux container can access to internet to avoid those kind of error with the git resource :
+# fatal: unable to access 'https://github.com/.../': Could not resolve host: github.com
+concourse_worker_forward_force_accept: yes

--- a/templates/concourse-worker.j2
+++ b/templates/concourse-worker.j2
@@ -2,6 +2,11 @@
 
 # {{ ansible_managed }}
 
+{% if concourse_worker_forward_force_accept|bool %}
+iptables -P FORWARD ACCEPT
+{% endif %}
+
+
 exec {{ concourse_install_dir }}/concourse worker \
   --tsa-host "{{ concourse_tsa_host }}:{{ concourse_tsa_port }}" \
   --tsa-public-key {{ concourse_tsa_public_key_path }} \


### PR DESCRIPTION
Make sure garden linux container can access to internet to avoid those kind of error with the git resource :
fatal: unable to access 'https://github.com/.../': Could not resolve host: github.com