### PR TITLE
concourse-worker: removed the MemoryLimit from the playbook (will be …

### DIFF
--- a/templates/concourse-worker.service.j2
+++ b/templates/concourse-worker.service.j2
@@ -14,7 +14,6 @@ RestartSec=10s
 LimitNPROC=infinity
 LimitNOFILE=infinity
 TasksMax=infinity
-MemoryLimit={{ (ansible_memtotal_mb * 0.9) | int | abs }}M
 Delegate=yes
 KillMode=process
 


### PR DESCRIPTION
…in the stack)

Linked to: https://github.com/cycloid-community-catalog/stack-external-worker/pull/52