### PR TITLE
worker: Create /usr/local/concourse symlink

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,29 @@
     group: "{{ concourse_group }}"
   become: yes
 
+- name: Ensure /usr/local/concourse is present | concourse
+  file:
+    path: "/usr/local/concourse"
+    state: directory
+    mode: 0755
+    owner: "{{ concourse_user }}"
+    group: "{{ concourse_group }}"
+  become: yes
+  when: concourse_binary_path | dirname != "/usr/local/concourse/bin"
+
+# Create a symlink in /usr/local/concourse because lot if Concourse default path target this directory.
+# this symlink is just here in case user forgot to override few env vars
+- name: Create /usr/local/concourse symbolic link | concourse
+  ansible.builtin.file:
+    src: "{{ concourse_binary_path | dirname }}"
+    dest: "/usr/local/concourse/bin"
+    state: link
+    mode: 0755
+    owner: "{{ concourse_user }}"
+    group: "{{ concourse_group }}"
+  become: yes
+  when: concourse_binary_path | dirname != "/usr/local/concourse/bin"
+
 - include: stop.yml
   when: needs_install
 


### PR DESCRIPTION
Create a symlink in /usr/local/concourse because lot if Concourse default path target this directory. this symlink is just here in case user forgot to override few env vars.

When changing Cocnourse binary path you need to specify several env vars such as
    CONCOURSE_CONTAINERD_BIN
    CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR
    CONCOURSE_CONTAINERD_INIT_BIN

But not all Concourse version allow you to specify all of them. And a user could potentially forgot one of them. Creating a default symlink just in case a user forgot one. This will ensure default env var values (using /usr/local/concourse) will work anyway