### PR TITLE
chore(update): replace old include module references with include_tasks in role

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
-- include: configure-web.yml
+- include_tasks: configure-web.yml
   when: concourse_web
 
-- include: configure-worker.yml
+- include_tasks: configure-worker.yml
   when: concourse_worker

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,7 +56,7 @@
   become: yes
   when: concourse_binary_path | dirname != "/usr/local/concourse/bin"
 
-- include: stop.yml
+- include_tasks: stop.yml
   when: needs_install
 
 # For Concourse version > 5
@@ -72,7 +72,7 @@
       become: yes
       register: binary_download
       tags:
-      - no-test
+        - no-test
     - name: unpack archive
       unarchive:
         src: "{{ concourse_install_dir }}/{{ concourse_archive_name }}"
@@ -85,8 +85,8 @@
       become: yes
       when: binary_download is not defined or binary_download is changed
       notify:
-      - restart concourse web
-      - restart concourse worker
+        - restart concourse web
+        - restart concourse worker
     - name: delete archive
       file:
         path: "{{ concourse_install_dir }}/{{ concourse_archive_name }}"
@@ -116,13 +116,13 @@
   when: needs_install and concourse_version is version('5.0', '<')
   register: binary_download
   notify:
-  - restart concourse web
-  - restart concourse worker
+    - restart concourse web
+    - restart concourse worker
 
 - name: install web | concourse
-  include: install-web.yml
+  include_tasks: install-web.yml
   when: concourse_web
 
 - name: install worker | concourse
-  include: install-worker.yml
+  include_tasks: install-worker.yml
   when: concourse_worker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: system.yml
-- include: install.yml
-- include: configure.yml
-- include: start.yml
+- include_tasks: system.yml
+- include_tasks: install.yml
+- include_tasks: configure.yml
+- include_tasks: start.yml
 
 - shell: /bin/true
   when: concourse_force_restart
   notify:
-  - restart concourse web
-  - restart concourse worker
+    - restart concourse web
+    - restart concourse worker


### PR DESCRIPTION
`include` module has been deprecated in 2.16 and throws an error in recent ansible versions. 
This prevents running this role on up-to-date ansible versions (>2.16)

I updated the two tasks using `include` to use the `include_tasks` module instead, which should behave the same. 

I can write tests if needs be.